### PR TITLE
Fixing stream url 

### DIFF
--- a/src/EnrichmentApi.php
+++ b/src/EnrichmentApi.php
@@ -51,7 +51,7 @@ class EnrichmentApi extends Api
 
     private function composeUrl($subdomain, $path, $query, $parameter)
     {
-        $streaming = $this->useStreaming ? '' : '-streaming';
+        $streaming = $this->useStreaming ? '-stream' : '';
         return sprintf(self::$apiUrlTemplate, $subdomain, $streaming, $path, $query, $parameter);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated the url used for the enrichment api to use the correct endpoint when stream or when not streaming. 

## Motivation and context

fixes #1 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
